### PR TITLE
feat: update config commands

### DIFF
--- a/base-cli/cmd/common/config/config.go
+++ b/base-cli/cmd/common/config/config.go
@@ -190,23 +190,13 @@ func (c *config) Set(name string, value any) error {
 		return err
 	}
 
-	switch item.Type {
-	case "string":
-		item.Value = anyToString(value)
-	case "int":
-		val, err := strconv.Atoi(anyToString(value))
+	if value != nil {
+		updatedValue, err := formattedValue(name, item.Type, value)
 		if err != nil {
 			return err
 		}
-		item.Value = val
-	case "bool":
-		val, err := strconv.ParseBool(anyToString(value))
-		if err != nil {
-			return err
-		}
-		item.Value = val
-	default:
-		return fmt.Errorf("unsupported type for config %s", name)
+
+		item.Value = updatedValue
 	}
 
 	if item.Validator != nil {
@@ -255,4 +245,25 @@ func nameToKey(name string) string {
 // key-to-name -> key_to_name
 func keyToName(key string) string {
 	return strings.ToLower(strings.ReplaceAll(key, "-", "_"))
+}
+
+func formattedValue(configName string, configType string, value any) (any, error) {
+	switch configType {
+	case "string":
+		return anyToString(value), nil
+	case "int":
+		val, err := strconv.Atoi(anyToString(value))
+		if err != nil {
+			return nil, err
+		}
+		return val, nil
+	case "bool":
+		val, err := strconv.ParseBool(anyToString(value))
+		if err != nil {
+			return nil, err
+		}
+		return val, nil
+	default:
+		return nil, fmt.Errorf("unsupported type for config %s", configName)
+	}
 }

--- a/base-cli/cmd/common/config/config.go
+++ b/base-cli/cmd/common/config/config.go
@@ -190,13 +190,6 @@ func (c *config) Set(name string, value any) error {
 		return err
 	}
 
-	if item.Validator != nil {
-		err = validator.NewValidator(value, *item.Validator).Validate()
-		if err != nil {
-			return err
-		}
-	}
-
 	switch item.Type {
 	case "string":
 		item.Value = anyToString(value)
@@ -214,6 +207,13 @@ func (c *config) Set(name string, value any) error {
 		item.Value = val
 	default:
 		return fmt.Errorf("unsupported type for config %s", name)
+	}
+
+	if item.Validator != nil {
+		err = validator.NewValidator(item.Value, *item.Validator).Validate()
+		if err != nil {
+			return err
+		}
 	}
 
 	err = structs.Set(&c.configYaml, keyToName(name), value)

--- a/base-cli/cmd/common/config/config.go
+++ b/base-cli/cmd/common/config/config.go
@@ -25,22 +25,22 @@ type Config interface {
 }
 
 type ConfigItem struct {
-	Name        string
-	Value       any
-	Type        string
-	Description string
-	Validator   *string
-	Default     any
-	Scope       string
+	Name        string  `json:"name"`
+	Value       any     `json:"value"`
+	Type        string  `json:"type"`
+	Description string  `json:"description"`
+	Validator   *string `json:"validator,omitempty"`
+	Default     any     `json:"default"`
+	Scope       string  `json:"scope"`
 }
 
 type ConfigSchema struct {
-	Name        string
-	Type        string
-	Description string
-	Validator   *string
-	Default     any
-	Scope       string
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	Description string  `json:"description"`
+	Validator   *string `json:"validator,omitempty"`
+	Default     any     `json:"default"`
+	Scope       string  `json:"scope"`
 }
 
 type CliConfig struct {

--- a/base-cli/cmd/common/config/config.go
+++ b/base-cli/cmd/common/config/config.go
@@ -16,6 +16,7 @@ import (
 
 type Config interface {
 	Get(name string) (*ConfigItem, error)
+	GetSchema(name string) (*ConfigSchema, error)
 	Set(name string, value any) error
 	Delete(name string) error
 	List() (map[string]*ConfigItem, error)
@@ -26,6 +27,15 @@ type Config interface {
 type ConfigItem struct {
 	Name        string
 	Value       any
+	Type        string
+	Description string
+	Validator   *string
+	Default     any
+	Scope       string
+}
+
+type ConfigSchema struct {
+	Name        string
 	Type        string
 	Description string
 	Validator   *string
@@ -235,6 +245,22 @@ func (c *config) Write() error {
 
 func (c *config) List() (map[string]*ConfigItem, error) {
 	return c.cliConfig.Items, nil
+}
+
+func (c *config) GetSchema(name string) (*ConfigSchema, error) {
+	config := c.cliConfig.Items[name]
+	if config == nil {
+		return nil, fmt.Errorf(`config "%s" not found`, name)
+	}
+
+	return &ConfigSchema{
+		Name:        config.Name,
+		Type:        config.Type,
+		Description: config.Description,
+		Validator:   config.Validator,
+		Default:     config.Default,
+		Scope:       config.Scope,
+	}, nil
 }
 
 // name_to_key -> name-to-key

--- a/base-cli/cmd/common/validator/int/int.go
+++ b/base-cli/cmd/common/validator/int/int.go
@@ -37,11 +37,11 @@ func Validator(value int, validateTag string) error {
 	}
 
 	if minimumValue > 0 && value < minimumValue {
-		return fmt.Errorf("value %d must be greater than %d", value, minimumValue)
+		return fmt.Errorf("value must be greater than %d", minimumValue)
 	}
 
 	if maximumValue > 0 && value > maximumValue {
-		return fmt.Errorf("value %d must be less than %d", value, maximumValue)
+		return fmt.Errorf("value must be less than %d", maximumValue)
 	}
 
 	return nil

--- a/base-cli/cmd/common/validator/str/str.go
+++ b/base-cli/cmd/common/validator/str/str.go
@@ -2,6 +2,7 @@ package str
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -10,12 +11,10 @@ func Validator(value string, validateTag string) error {
 	if strings.Contains(validateTag, "oneof=") {
 		oneof := strings.Split(validateTag, "oneof=")[1]
 		oneofValues := strings.Split(oneof, ",")
-		for _, oneofValue := range oneofValues {
-			if oneofValue == value {
-				return nil
-			}
+		if slices.Contains(oneofValues, value) {
+			return nil
 		}
-		return fmt.Errorf("value %s must be one of %s", value, oneofValues)
+		return fmt.Errorf("value must be one of %s", oneofValues)
 	}
 
 	return nil

--- a/base-cli/cmd/common/validator/validator.go
+++ b/base-cli/cmd/common/validator/validator.go
@@ -25,6 +25,9 @@ func NewValidator(value any, validateTag string) Validator {
 func (v *validator) Validate() error {
 	//reflect on type of v.value and call the appropriate validator
 	typ := reflect.TypeOf(v.value)
+	if typ == nil {
+		return nil
+	}
 	switch typ.Kind() {
 	case reflect.Int:
 		return v.integer()

--- a/base-cli/cmd/root.go
+++ b/base-cli/cmd/root.go
@@ -372,9 +372,9 @@ func beautifulPrint(cmd *cobra.Command) {
 
 				if detail != "" {
 					beautifulOutput.PrintError(fmt.Sprintf("%s: %s", msg, detail))
+				} else {
+					beautifulOutput.PrintError(msg)
 				}
-
-				beautifulOutput.PrintError(msg)
 
 				cmd.SetContext(context.WithValue(cmd.Context(), cmdutils.CTX_ERROR_HANDLED, true))
 			}

--- a/base-cli/cmd/static/config/config.go
+++ b/base-cli/cmd/static/config/config.go
@@ -24,6 +24,7 @@ func ConfigCmd(parent *cobra.Command) {
 	cmd.AddCommand(Delete(config))
 	cmd.AddCommand(Get(config))
 	cmd.AddCommand(Set(config))
+	cmd.AddCommand(GetSchema(config))
 
 	parent.AddCommand(cmd)
 }

--- a/base-cli/cmd/static/config/delete.go
+++ b/base-cli/cmd/static/config/delete.go
@@ -5,26 +5,42 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/magaluCloud/mgccli/cmd/common/config"
+	cmdutils "github.com/magaluCloud/mgccli/cmd_utils"
 	"github.com/spf13/cobra"
 )
 
+type DeleteOptions struct {
+	Key string
+}
+
 func Delete(config config.Config) *cobra.Command {
+	var opts GetOptions
+
 	cmd := &cobra.Command{
 		Use:   "delete [config]",
 		Short: "Deletar configurações",
 		Long:  `Deletar configurações`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 {
-				fmt.Println("Erro: configuração não especificada")
-				return
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := opts.Key
+			if len(args) > 0 {
+				key = args[0]
 			}
-			err := config.Delete(args[0])
+
+			if key == "" {
+				return cmdutils.NewCliError("missing required flag: --key=string")
+			}
+
+			err := config.Delete(key)
 			if err != nil {
-				fmt.Println("Erro ao deletar configuração:", err)
-				return
+				return cmdutils.NewCliError(err.Error())
 			}
-			fmt.Println(color.GreenString("Configuração deletada com sucesso"))
+
+			fmt.Println(color.GreenString("Configuration deleted successfully"))
+			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&opts.Key, "key", "", "Name of the desired config (required)")
+
 	return cmd
 }

--- a/base-cli/cmd/static/config/get.go
+++ b/base-cli/cmd/static/config/get.go
@@ -1,30 +1,45 @@
 package config
 
 import (
-	"fmt"
-
-	"github.com/fatih/color"
+	"github.com/magaluCloud/mgccli/beautiful"
 	"github.com/magaluCloud/mgccli/cmd/common/config"
+	cmdutils "github.com/magaluCloud/mgccli/cmd_utils"
 	"github.com/spf13/cobra"
 )
 
+type GetOptions struct {
+	Key string
+}
+
 func Get(config config.Config) *cobra.Command {
+	var opts GetOptions
+
 	cmd := &cobra.Command{
-		Use:   "get [config]",
+		Use:   "get [key]",
 		Short: "Obter configurações",
 		Long:  `Obter configurações`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 {
-				fmt.Println("Erro: configuração não especificada")
-				return
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := opts.Key
+			if len(args) > 0 {
+				key = args[0]
 			}
-			value, err := config.Get(args[0])
+
+			if key == "" {
+				return cmdutils.NewCliError("missing required flag: --key=string")
+			}
+
+			value, err := config.Get(key)
 			if err != nil {
-				fmt.Println("Erro ao obter configuração:", err)
-				return
+				return cmdutils.NewCliError(err.Error())
 			}
-			fmt.Printf("%s: %v\n", color.BlueString(args[0]), color.YellowString(fmt.Sprintf("%v", value.Value)))
+
+			beautiful.NewOutput(false).PrintData(map[string]any{key: value.Value})
+
+			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&opts.Key, "key", "", "Name of the desired config (required)")
+
 	return cmd
 }

--- a/base-cli/cmd/static/config/get_schema.go
+++ b/base-cli/cmd/static/config/get_schema.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"github.com/magaluCloud/mgccli/beautiful"
+	"github.com/magaluCloud/mgccli/cmd/common/config"
+	cmdutils "github.com/magaluCloud/mgccli/cmd_utils"
+	"github.com/spf13/cobra"
+)
+
+type GetSchemaOptions struct {
+	Key string
+}
+
+func GetSchema(config config.Config) *cobra.Command {
+	var opts GetSchemaOptions
+
+	cmd := &cobra.Command{
+		Use:   "get-schema [key]",
+		Short: "Obter schema da configuração especificada",
+		Long:  `Obter schema da configuração especificada`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := opts.Key
+			if len(args) > 0 {
+				key = args[0]
+			}
+
+			if key == "" {
+				return cmdutils.NewCliError("missing required flag: --key=string")
+			}
+
+			configMap, err := config.GetSchema(key)
+			if err != nil {
+				return cmdutils.NewCliError(err.Error())
+			}
+
+			beautiful.NewOutput(false).PrintData(configMap)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Key, "key", "", "Name of the desired config (required)")
+
+	return cmd
+}

--- a/base-cli/cmd/static/config/list.go
+++ b/base-cli/cmd/static/config/list.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"fmt"
 	"reflect"
 
-	"github.com/fatih/color"
+	"github.com/magaluCloud/mgccli/beautiful"
 	"github.com/magaluCloud/mgccli/cmd/common/config"
+	cmdutils "github.com/magaluCloud/mgccli/cmd_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -14,24 +14,19 @@ func List(config config.Config) *cobra.Command {
 		Use:   "list",
 		Short: "Listar configurações",
 		Long:  `Listar configurações`,
-		Run: func(cmd *cobra.Command, args []string) {
-
+		RunE: func(cmd *cobra.Command, args []string) error {
 			configMap, err := config.List()
 			if err != nil {
-				fmt.Println("Erro ao listar configurações:", err)
-				return
+				return cmdutils.NewCliError(err.Error())
 			}
+
 			for key, value := range configMap {
-				fmt.Printf("Name: %s\n   Value: %v\n   Type: %s\n   Description: %s\n   Validator: %s\n   Default: %v\n   Scope: %s\n\n",
-					color.BlueString(key),
-					color.YellowString(fmt.Sprintf("%v", valueOrDefault(value.Value, value.Default))),
-					value.Type,
-					value.Description,
-					validatorOrEmpty(value.Validator),
-					value.Default,
-					value.Scope,
-				)
+				configMap[key].Value = valueOrDefault(value.Value, value.Default)
 			}
+
+			beautiful.NewOutput(false).PrintData(configMap)
+
+			return nil
 		},
 	}
 	return cmd
@@ -42,11 +37,4 @@ func valueOrDefault(value any, defaultValue any) any {
 		return defaultValue
 	}
 	return value
-}
-
-func validatorOrEmpty(validator *string) string {
-	if validator == nil {
-		return ""
-	}
-	return *validator
 }

--- a/base-cli/cmd/static/config/set.go
+++ b/base-cli/cmd/static/config/set.go
@@ -8,24 +8,45 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type SetOptions struct {
+	Key   string
+	Value string
+}
+
 func Set(config config.Config) *cobra.Command {
+	var opts SetOptions
+
 	cmd := &cobra.Command{
-		Use:   "set [config] [value]",
+		Use:   "set [key] [value]",
 		Short: "Definir configurações",
 		Long:  `Definir configurações`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) < 2 {
-				fmt.Println("Erro: configuração e valor não especificados")
+			key := opts.Key
+			value := opts.Value
+
+			if len(args) > 0 {
+				key = args[0]
+			}
+			if len(args) > 1 {
+				value = args[1]
+			}
+
+			if key == "" || value == "" {
+				fmt.Println("Erro: chave e/ou valor não especificados")
 				return
 			}
 
-			err := config.Set(args[0], args[1])
+			err := config.Set(key, value)
 			if err != nil {
 				fmt.Println("Erro ao definir configuração:", err)
 				return
 			}
-			fmt.Printf("%s: %v\n", color.BlueString(args[0]), color.YellowString(args[1]))
+			fmt.Printf("%s: %v\n", color.BlueString(key), color.YellowString(value))
 		},
 	}
+
+	cmd.Flags().StringVar(&opts.Key, "key", "", "Nome da configuração desejada (required)")
+	cmd.Flags().StringVar(&opts.Value, "value", "", "Valor da configuração desejada (required)")
+
 	return cmd
 }

--- a/base-cli/cmd/static/config/set.go
+++ b/base-cli/cmd/static/config/set.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/magaluCloud/mgccli/cmd/common/config"
+	cmdutils "github.com/magaluCloud/mgccli/cmd_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +21,7 @@ func Set(config config.Config) *cobra.Command {
 		Use:   "set [key] [value]",
 		Short: "Definir configurações",
 		Long:  `Definir configurações`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			key := opts.Key
 			value := opts.Value
 
@@ -31,22 +32,29 @@ func Set(config config.Config) *cobra.Command {
 				value = args[1]
 			}
 
-			if key == "" || value == "" {
-				fmt.Println("Erro: chave e/ou valor não especificados")
-				return
+			if key == "" && value == "" {
+				return cmdutils.NewCliError("missing required flags: --key=string, --value=any")
+			}
+			if key == "" {
+				return cmdutils.NewCliError("missing required flag: --key=string")
+			}
+			if value == "" {
+				return cmdutils.NewCliError("missing required flag: --value=any")
 			}
 
 			err := config.Set(key, value)
 			if err != nil {
-				fmt.Println("Erro ao definir configuração:", err)
-				return
+				return cmdutils.NewCliError(err.Error())
 			}
+
 			fmt.Printf("%s: %v\n", color.BlueString(key), color.YellowString(value))
+
+			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.Key, "key", "", "Nome da configuração desejada (required)")
-	cmd.Flags().StringVar(&opts.Value, "value", "", "Valor da configuração desejada (required)")
+	cmd.Flags().StringVar(&opts.Key, "key", "", "Name of the desired config (required)")
+	cmd.Flags().StringVar(&opts.Value, "value", "", "Value of the desired config (exactly one of: string, integer or boolean) (required)")
 
 	return cmd
 }

--- a/base-cli/cmd/static/config/set.go
+++ b/base-cli/cmd/static/config/set.go
@@ -1,9 +1,7 @@
 package config
 
 import (
-	"fmt"
-
-	"github.com/fatih/color"
+	"github.com/magaluCloud/mgccli/beautiful"
 	"github.com/magaluCloud/mgccli/cmd/common/config"
 	cmdutils "github.com/magaluCloud/mgccli/cmd_utils"
 	"github.com/spf13/cobra"
@@ -47,7 +45,7 @@ func Set(config config.Config) *cobra.Command {
 				return cmdutils.NewCliError(err.Error())
 			}
 
-			fmt.Printf("%s: %v\n", color.BlueString(key), color.YellowString(value))
+			beautiful.NewOutput(false).PrintData(map[string]any{key: value})
 
 			return nil
 		},


### PR DESCRIPTION
Ajustes nos comandos de config:
- Adicionado o comando `get-schema`
- Corrigido o `delete` pois estava dando erro ao executar o comando
- Corrigido a validação dos valores no `set` pois estava sempre considerando o valor como string, não entrando na validação dos números (ex: chunk-size estava permitindo o valor 0 porém o mínimo é 1)
- Adicionado a opção de utilizar a flag `--key` nos comandos para ficar igual a CLI atual
- Corrigido para não retornar a mensagem de erro duplicado
- Ajustado como é mostrado as informações no terminal para utilizar o `PrintData`. Ajuste feito para no futuro conseguirmos adicionar o formato `table`